### PR TITLE
feat: Temporarily moving marking payment as paid to market page for p…

### DIFF
--- a/site/src/app/(platform)/marketplace/_components/column-actions.tsx
+++ b/site/src/app/(platform)/marketplace/_components/column-actions.tsx
@@ -33,6 +33,7 @@ import { Label } from "@/components/ui/label";
 import { store_stock_purchase } from "@/server-actions/buy/stock_holdings";
 // import { useAppKitAccount } from "@reown/appkit/react";
 import { useAccountId, useWallet } from "@buidlerlabs/hashgraph-react-wallets";
+import markRequestAsPaid from "@/server-actions/mpesa/markPaid";
 
 // import updateUserStockHoldings from "@/server-actions/stocks/update_stock_holdings";
 // Defines the form value type from the schema
@@ -91,6 +92,9 @@ export function ColumnActions({ entry }: { entry: StockData }) {
         purchase_date: new Date(),
         transaction_type: "buy",
       });
+
+      // Mark payment as paid
+      await markRequestAsPaid(mpesa_request_id);
 
       // Show success message
       toast.info(`Sent, waiting for payment confirmation...`);

--- a/site/src/app/api/payment/route.ts
+++ b/site/src/app/api/payment/route.ts
@@ -1,24 +1,25 @@
-import markRequestAsPaid from "@/server-actions/mpesa/markPaid";
+// import markRequestAsPaid from "@/server-actions/mpesa/markPaid";
 
 export async function POST(request: Request) {
   console.log("Webhook got called");
-  // Check if the payment was succesful
-  const data = await request.json();
-  if (!data.Body.stkCallback.CallbackMetadata) {
-    // Not succesful
-    console.log("Payment request was not succesful");
-    return Response.json({ message: "Okay" }, { status: 200 });
-  }
+  console.log(request);
+  // // Check if the payment was succesful
+  // const data = await request.json();
+  // if (!data.Body.stkCallback.CallbackMetadata) {
+  //   // Not succesful
+  //   console.log("Payment request was not succesful");
+  //   return Response.json({ message: "Okay" }, { status: 200 });
+  // }
 
-  // Succesful response
-  const mpesa_id = data.Body.stkCallback.MerchantRequestID;
-  if (mpesa_id) {
-    try {
-      await markRequestAsPaid(mpesa_id);
-    } catch(err) {
-      console.log("Error marking payment as paid", err);
-    }
-  }
+  // // Succesful response
+  // const mpesa_id = data.Body.stkCallback.MerchantRequestID;
+  // if (mpesa_id) {
+  //   try {
+  //     await markRequestAsPaid(mpesa_id);
+  //   } catch(err) {
+  //     console.log("Error marking payment as paid", err);
+  //   }
+  // }
 
   return Response.json({ message: "Okay" }, { status: 200 });
 }


### PR DESCRIPTION
## Summary

Marking the payment as paid immediately after paying for presentation sake

## Detailed

I've noticed that the webhook handling process is very unreliable and unpredictable. For the sake of the presentation i have decided to move the functionality from marking a payment as paid from the webhook to immediately after STK push is made.

This has the disadvantage of not confirming if a payment has been made but for the sake of presentation it is necessary