### PR TITLE
Updated getStocks and ViewButton

### DIFF
--- a/site/src/app/(platform)/marketplace/_components/view-button.tsx
+++ b/site/src/app/(platform)/marketplace/_components/view-button.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { IconBinoculars } from "@tabler/icons-react";
+import { IconEye } from "@tabler/icons-react";
 import { useRouter } from "next/navigation";
 
 export function ViewButton({ symbol }: { symbol: string }) {
@@ -12,7 +12,7 @@ export function ViewButton({ symbol }: { symbol: string }) {
       size="sm"
       onClick={() => router.push(`/marketplace/${symbol}`)}
     >
-      <IconBinoculars className="h-4 w-4 mr-1" />
+      <IconEye className="h-4 w-4 mr-1" />
       View
     </Button>
   );

--- a/site/src/server-actions/stocks/getStocks.ts
+++ b/site/src/server-actions/stocks/getStocks.ts
@@ -62,7 +62,7 @@ const getStockPricesWithCache = unstable_cache(
     return await getStockPrices();
   },
   ["stock-prices"],
-  { revalidate: 30 }, // 30 seconds
+  { revalidate: 50 }, // 50 seconds
 );
 
 export async function getStockPrices(): Promise<STOCKPRICES[]> {


### PR DESCRIPTION
This pull request includes changes to the `view-button.tsx` and `getStocks.ts` files to update the icon used in the view button and adjust the cache revalidation period for stock prices.

Updates to `view-button.tsx`:

* Changed the icon from `IconBinoculars` to `IconEye` to improve the visual representation of the view button. [[1]](diffhunk://#diff-afd6533b57a9ac5a4cfca28a45a6eee93ed1cf622f52ebcf5d2382474cf2d890L4-R4) [[2]](diffhunk://#diff-afd6533b57a9ac5a4cfca28a45a6eee93ed1cf622f52ebcf5d2382474cf2d890L15-R15)

Adjustments to caching in `getStocks.ts`:

* Increased the revalidation period for stock prices from 30 seconds to 50 seconds to reduce the frequency of cache updates.